### PR TITLE
fix: change the mix task module name

### DIFF
--- a/lib/mix/tasks/prepare.ex
+++ b/lib/mix/tasks/prepare.ex
@@ -1,4 +1,4 @@
-defmodule Mix.Tasks.Prepare do
+defmodule Mix.Tasks.ExArk.Prepare do
   @moduledoc """
   Alias for the project linter.
   """


### PR DESCRIPTION
The library is being vendored in another repo for now, which has a mix task of the same name. Qualify the task with the root module name, but in the proper format required by the mix task naming convention.