### PR TITLE
feat: handle enums as complex type

### DIFF
--- a/lib/ex_ark/serdes/input_stream.ex
+++ b/lib/ex_ark/serdes/input_stream.ex
@@ -61,9 +61,6 @@ defmodule ExArk.Serdes.InputStream do
       Types.primitive_type?(type) ->
         read_field_primitive(stream, type)
 
-      Types.enum_type?(type) ->
-        read_field_enum(stream, field, registry)
-
       Types.complex_type?(type) ->
         read_field_complex(stream, field, registry, type)
 
@@ -73,11 +70,6 @@ defmodule ExArk.Serdes.InputStream do
   end
 
   defp read_field_primitive(stream, type) do
-    Primitives.read(type, stream)
-  end
-
-  defp read_field_enum(stream, field, registry) do
-    type = registry.enums[field.object_type].enum_class
     Primitives.read(type, stream)
   end
 

--- a/lib/ex_ark/serdes/output_stream.ex
+++ b/lib/ex_ark/serdes/output_stream.ex
@@ -44,9 +44,6 @@ defmodule ExArk.Serdes.OutputStream do
       Types.primitive_type?(type) ->
         write_field_primitive(stream, type, data)
 
-      Types.enum_type?(type) ->
-        write_field_enum(stream, field, data, registry)
-
       Types.complex_type?(type) ->
         write_field_complex(stream, field, data, registry, type)
 
@@ -60,11 +57,6 @@ defmodule ExArk.Serdes.OutputStream do
 
   defp write_field_primitive(stream, type, data) do
     Primitives.write(type, data, stream)
-  end
-
-  defp write_field_enum(stream, field, data, registry) do
-    enum_type = registry.enums[field.object_type].enum_class
-    Primitives.write(enum_type, data, stream)
   end
 
   defp write_field_complex(stream, field, data, registry, type) do

--- a/lib/ex_ark/types.ex
+++ b/lib/ex_ark/types.ex
@@ -23,18 +23,15 @@ defmodule ExArk.Types do
     :steady_time_point,
     :system_time_point
   ]
-  @enum_types [:enum]
-  @complex_types [:array, :arraylist, :dictionary, :object, :variant]
-  @all_types @primitive_types ++ @enum_types ++ @complex_types
+  @complex_types [:array, :arraylist, :dictionary, :object, :variant, :enum]
+  @all_types @primitive_types ++ @complex_types
 
   union_type primitive_type :: @primitive_types
-  union_type enum_type :: @enum_types
   union_type complex_type :: @complex_types
   union_type types :: @all_types
 
-  @type ark_type :: primitive_type() | enum_type() | complex_type() | String.t()
+  @type ark_type :: primitive_type() | complex_type() | String.t()
 
-  @enum_type_names Enum.map(@enum_types, &Atom.to_string/1)
   @primitive_type_names Enum.map(@primitive_types, &Atom.to_string/1)
 
   @doc """
@@ -46,19 +43,11 @@ defmodule ExArk.Types do
   def primitive_type?(_type), do: false
 
   @doc """
-  Checks if the given type is an enum type.
-  """
-  @spec enum_type?(ark_type()) :: boolean()
-  def enum_type?(type) when is_binary(type), do: type in @enum_type_names
-  def enum_type?(:enum), do: true
-  def enum_type?(_), do: false
-
-  @doc """
   Checks if the given type is a complex type.
   """
   @spec complex_type?(ark_type()) :: boolean()
   def complex_type?(type) when is_binary(type), do: complex_type?(String.to_existing_atom(type))
-  def complex_type?(type), do: !primitive_type?(type) and !enum_type?(type)
+  def complex_type?(type), do: !primitive_type?(type)
 
   @doc """
   Gets the module responsible for handling the given complex type.
@@ -70,6 +59,7 @@ defmodule ExArk.Types do
       :dictionary -> ExArk.Types.Dictionary
       :object -> ExArk.Types.Object
       :variant -> ExArk.Types.Variant
+      :enum -> ExArk.Types.ArkEnum
     end
   end
 end

--- a/lib/ex_ark/types/enum.ex
+++ b/lib/ex_ark/types/enum.ex
@@ -1,0 +1,30 @@
+defmodule ExArk.Types.ArkEnum do
+  @moduledoc """
+  Module for handling enums
+  """
+  alias ExArk.Ir.Field
+  alias ExArk.Registry
+  alias ExArk.Serdes.InputStream
+  alias ExArk.Serdes.InputStream.Result, as: Result
+  alias ExArk.Serdes.OutputStream
+  alias ExArk.Types.Primitives
+
+  require Logger
+
+  @spec read(InputStream.t(), Field.t(), Registry.t()) :: {:ok, Result.t()} | InputStream.failure()
+  def read(%InputStream{} = stream, %Field{} = field, %Registry{} = registry) do
+    enum = registry.enums[field.object_type]
+    {:ok, %Result{stream: stream, reified: value}} = Primitives.read(enum.enum_class, stream)
+    # When we read the enum, return the name (key).
+    {key, _value} = Enum.find(enum.values, fn {_k, v} -> v == value end)
+    {:ok, %Result{stream: stream, reified: key}}
+  end
+
+  @spec write(OutputStream.t(), Field.t(), any(), Registry.t()) :: {:ok, OutputStream.t()} | OutputStream.failure()
+  def write(%OutputStream{} = stream, %Field{} = field, key, %Registry{} = registry) do
+    enum = registry.enums[field.object_type]
+    # When we write the enum, we use the value for the key.
+    {_key, value} = Enum.find(enum.values, fn {k, _v} -> k == key end)
+    Primitives.write(enum.enum_class, value, stream)
+  end
+end


### PR DESCRIPTION
Handle enums as complex types. Map the enum value to the name during deserialization, and the name to the value during serialization.