### PR TITLE
chore: unify removed field behaviour across different objects

### DIFF
--- a/lib/ex_ark/serdes/json/object.ex
+++ b/lib/ex_ark/serdes/json/object.ex
@@ -38,7 +38,7 @@ defmodule ExArk.Serdes.Json.Object do
     present = Map.has_key?(reader.decoded, field.name)
 
     cond do
-      removed && !present ->
+      removed ->
         {:ok, %ReaderResult{reified: reified}}
 
       !optional && !present ->

--- a/test/ex_ark/serdes/json/object_test.exs
+++ b/test/ex_ark/serdes/json/object_test.exs
@@ -165,14 +165,14 @@ defmodule ExArk.Serdes.Json.ObjectTest do
       refute Map.has_key?(decoded, "removed_field")
     end
 
-    test "removed fields - deserialization keeps removed field when present", %{registry: registry} do
+    test "removed fields - deserialization ignores removed field when present", %{registry: registry} do
       json = JSON.encode!(%{"required_field" => "test", "removed_field" => 42})
       type = "ex_ark::test::ObjectWithRemovedField"
 
       {:ok, deserialized} = ExArk.read_object_from_json(registry, type, json)
 
       assert deserialized.required_field == "test"
-      assert deserialized.removed_field == 42
+      refute Map.has_key?(deserialized, :removed_field)
     end
 
     test "removed fields - deserialization succeeds when removed field is missing", %{registry: registry} do
@@ -183,6 +183,13 @@ defmodule ExArk.Serdes.Json.ObjectTest do
 
       assert deserialized.required_field == "test"
       refute Map.has_key?(deserialized, :removed_field)
+    end
+
+    test "removed fields - required field is still required", %{registry: registry} do
+      json = JSON.encode!(%{"removed_field" => 42})
+      type = "ex_ark::test::ObjectWithRemovedField"
+
+      assert {:error, :deserialization_error} = ExArk.read_object_from_json(registry, type, json)
     end
 
     test "final roundtrip", %{registry: registry} do


### PR DESCRIPTION
JSON deserialization is going to ignore removed fields, which aligns it with the existing binary behavior and prevents removed fields from leaking into runtime maps.