### PR TITLE
fix: preserve reified map when skipping unknown group on deserialize

### DIFF
--- a/lib/ex_ark/serdes/binary/object.ex
+++ b/lib/ex_ark/serdes/binary/object.ex
@@ -113,7 +113,7 @@ defmodule ExArk.Serdes.Binary.Object do
       if group != nil do
         deserialize_fields(stream, group.fields, registry, reified)
       else
-        {:ok, %Result{stream: InputStream.advance(stream, header.group_size)}}
+        {:ok, %Result{stream: InputStream.advance(stream, header.group_size), reified: reified}}
       end
     end
   end

--- a/test/ex_ark/serdes/binary/object_test.exs
+++ b/test/ex_ark/serdes/binary/object_test.exs
@@ -74,6 +74,33 @@ defmodule ExArk.Serdes.Binary.ObjectTest do
       assert deserialized == data
     end
 
+    test "unknown group - skips a group the reader's schema does not have", %{registry: registry} do
+      # Simulate schema skew: the writer's schema has an extra optional group (identifier 1)
+      # that the reader's schema does not know about. Deserializing must skip the unknown
+      # group's bytes and preserve the fields it does understand, rather than crashing with a
+      # BadMapError from Map.merge/2 on a nil accumulator.
+      data = %{
+        id: "test-id",
+        value: 42,
+        group_field_1: "group-value",
+        group_field_2: 99,
+        extra_field: 7
+      }
+
+      {:ok, serialized} =
+        ExArk.write_object_to_bytes(registry, "ex_ark::test::ObjectWithExtraGroup", data)
+
+      {:ok, deserialized} =
+        ExArk.read_object_from_bytes(registry, "ex_ark::test::ObjectWithOptionalGroup", serialized)
+
+      # Known base fields and known group (identifier 0) survive; the unknown group is dropped.
+      assert deserialized.id == "test-id"
+      assert deserialized.value == 42
+      assert deserialized.group_field_1 == "group-value"
+      assert deserialized.group_field_2 == 99
+      refute Map.has_key?(deserialized, :extra_field)
+    end
+
     test "optional fields - missing optional fields", %{registry: registry} do
       # Data with only required fields, no optional fields
       data = %{required_field: "test", another_required_field: 42}

--- a/test/fixtures/ir/objects.ir
+++ b/test/fixtures/ir/objects.ir
@@ -141,6 +141,48 @@
       }
     },
     {
+      "name": "ObjectWithExtraGroup",
+      "object_namespace": "ex_ark::test",
+      "fields": [
+        {
+          "name": "id",
+          "type": "string"
+        },
+        {
+          "name": "value",
+          "type": "int32"
+        }
+      ],
+      "groups": [
+        {
+          "identifier": 0,
+          "fields": [
+            {
+              "name": "group_field_1",
+              "type": "string"
+            },
+            {
+              "name": "group_field_2",
+              "type": "int32"
+            }
+          ]
+        },
+        {
+          "identifier": 1,
+          "fields": [
+            {
+              "name": "extra_field",
+              "type": "int32"
+            }
+          ]
+        }
+      ],
+      "source_location": {
+        "filename": "test/ex_ark/fixtures/objects.ir",
+        "line_number": 1
+      }
+    },
+    {
       "name": "ObjectWithOptionalFields",
       "object_namespace": "ex_ark::test",
       "fields": [


### PR DESCRIPTION
When binary deserialization encounters an optional group whose identifier is not in the reader's schema (writer serialized with a newer schema), the skip branch built a Result without :reified, defaulting it to nil. The caller then ran Map.merge/2 on that nil, raising BadMapError and aborting the whole decode instead of skipping the unknown group as intended.

Thread the accumulated reified map through the skip branch so forward-compat group skew deserializes cleanly. Adds a regression test that reproduces the crash via an ObjectWithExtraGroup writer / ObjectWithOptionalGroup reader.