### PR TITLE
fix: avoid runtime dependency on Mix

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
-erlang 28.3.2
-elixir 1.19.5-otp-28
+erlang 29.0.2
+elixir 1.20.2-otp-29

--- a/lib/ex_ark/serdes/binary/fields/variant.ex
+++ b/lib/ex_ark/serdes/binary/fields/variant.ex
@@ -92,7 +92,8 @@ defmodule ExArk.Serdes.Binary.Fields.Variant do
 
   defp update_length(%OutputStream{} = stream, start_offset) do
     length = stream.offset - start_offset
-    <<prefix::binary-size(start_offset - 4), _old::little-unsigned-integer-size(32), rest::binary>> = stream.bytes
+    length_offset = start_offset - 4
+    <<prefix::binary-size(^length_offset), _old::little-unsigned-integer-size(32), rest::binary>> = stream.bytes
 
     {:ok,
      %OutputStream{

--- a/lib/ex_ark/serdes/binary/input_stream.ex
+++ b/lib/ex_ark/serdes/binary/input_stream.ex
@@ -27,7 +27,7 @@ defmodule ExArk.Serdes.Binary.InputStream do
 
   @spec advance(t(), non_neg_integer()) :: t()
   def advance(%__MODULE__{} = stream, count) do
-    <<_drop::binary-size(count), rest::binary>> = stream.bytes
+    <<_drop::binary-size(^count), rest::binary>> = stream.bytes
     %__MODULE__{stream | bytes: rest, offset: stream.offset + count}
   end
 end

--- a/lib/ex_ark/serdes/binary/optional_group_header.ex
+++ b/lib/ex_ark/serdes/binary/optional_group_header.ex
@@ -26,7 +26,8 @@ defmodule ExArk.Serdes.Binary.OptionalGroupHeader do
   @magic 0xE
   @group_header_size 6
 
-  def read(%InputStream{bytes: <<@magic::4, 0::1, sections::1, 0::2, rest::binary>>, offset: offset} = stream) do
+  def read(%InputStream{bytes: <<@magic::4, 0::1, sections::1, 0::2, rest::binary>>, offset: offset} = stream)
+      when byte_size(rest) >= 5 do
     stream = %{stream | bytes: rest, offset: offset + 1, has_more_sections: sections != 0}
 
     with {:ok, %Result{stream: stream, reified: identifier}} <- Primitives.read(:uint8, stream),
@@ -39,11 +40,11 @@ defmodule ExArk.Serdes.Binary.OptionalGroupHeader do
            group_size: group_size
          }
        }}
-    else
-      _ ->
-        {:error, :bad_optional_group_header}
     end
   end
+
+  def read(%InputStream{bytes: <<@magic::4, 0::1, _sections::1, 0::2, _rest::binary>>}),
+    do: {:error, :bad_optional_group_header}
 
   def read(%InputStream{bytes: <<_magic::4, 0::1, _sections::1, 0::2, _rest::binary>>}),
     do: {:error, :bad_magic}

--- a/lib/ex_ark/utilities.ex
+++ b/lib/ex_ark/utilities.ex
@@ -3,6 +3,8 @@ defmodule ExArk.Utilities do
   Internal utility functions shared across ExArk modules.
   """
 
+  @mix_env Mix.env()
+
   @doc """
   Convert a string to an atom, guarding against atom-table exhaustion in
   production.
@@ -14,7 +16,7 @@ defmodule ExArk.Utilities do
   """
   @spec ensure_existing_atom(binary()) :: atom()
   def ensure_existing_atom(identifier) when is_binary(identifier) do
-    if Mix.env() == :test do
+    if @mix_env == :test do
       String.to_atom(identifier)
     else
       String.to_existing_atom(identifier)

--- a/test/ex_ark/serdes/binary/optional_group_header_test.exs
+++ b/test/ex_ark/serdes/binary/optional_group_header_test.exs
@@ -1,0 +1,12 @@
+defmodule ExArk.Serdes.Binary.OptionalGroupHeaderTest do
+  use ExUnit.Case, async: true
+
+  alias ExArk.Serdes.Binary.InputStream
+  alias ExArk.Serdes.Binary.OptionalGroupHeader
+
+  test "returns an error for a truncated optional group header" do
+    stream = %InputStream{bytes: <<0xE0, 1, 2, 3, 4>>}
+
+    assert {:error, :bad_optional_group_header} = OptionalGroupHeader.read(stream)
+  end
+end

--- a/test/ex_ark/utilities_test.exs
+++ b/test/ex_ark/utilities_test.exs
@@ -1,0 +1,12 @@
+defmodule ExArk.UtilitiesTest do
+  use ExUnit.Case, async: true
+
+  alias ExArk.Utilities
+
+  test "does not depend on Mix at runtime" do
+    assert {Utilities, beam, _filename} = :code.get_object_code(Utilities)
+    assert {:ok, {Utilities, [imports: imports]}} = :beam_lib.chunks(beam, [:imports])
+
+    refute {Mix, :env, 0} in imports
+  end
+end


### PR DESCRIPTION
Capture the Mix environment at compile time so ExArk works in production releases where the Mix application is unavailable.

Add a regression test ensuring ExArk.Utilities does not import Mix.env/0 at runtime.